### PR TITLE
Fixed minor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd adgone
 
 chmod 755 adgone.sh
 
-sudo ./addgone.sh 
+sudo ./adgone.sh 
 ```
 ## Shoutout to the hero
 


### PR DESCRIPTION
The command for running the code should be "sudo ./adgone.sh". The name of the file is misspelt as "addgone.sh".